### PR TITLE
Added unique_ids for all elements, added config options name_regexp (…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ Easiest way to install this component is through [HACS][hacs].
 Configuration through `configuration.yaml`, not available in UI yet.
 
 Example Config:
+
 ```
 wattbox:
 - host: 192.168.1.100
   name: wattbox1
   username: username1
   password: password1
+  name_regexp: "^Fixed Prefix (.*)$"
+  skip_regexp: "SKIP"
   scan_interval: 00:00:10
 - host: 192.168.1.101
   name: wattbox2
@@ -40,40 +43,46 @@ wattbox:
 
 Configuration Options:
 
-* *host*: Host IP of the WattBox (Required)
-* *port*: Port of the HTTP interface (Default 80)
-* *username*: Username for authentication (Default wattbox)
-* *password*: Password for authentication (Default wattbox)
-* *name*: Name for the WattBox (Default wattbox)
-* *resources*: A list of resources to enable (Default all of them)
-* *scan_interval*: A time interval run updates at (Default 30s, format HH:MM:SS)
+- _host_: Host IP of the WattBox (Required)
+- _port_: Port of the HTTP interface (Default 80)
+- _username_: Username for authentication (Default wattbox)
+- _password_: Password for authentication (Default wattbox)
+- _name_: Name for the WattBox (Default wattbox)
+- _resources_: A list of resources to enable (Default all of them)
+- _scan_interval_: A time interval run updates at (Default 30s, format HH:MM:SS)
+- _name_regexp_: A regexp to extract the name to use for the outlet instead of just the index. If there is a match group, it is used, else the whole match is used.
+- _skip_regexp_: A regexp to use that, if the outlet name matches, the outlet is not added as a switch entity.
 
 Resources:
-* audible_alarm
-* auto_reboot
-* battery_health
-* battery_test
-* cloud_status
-* has_ups
-* mute
-* power_lost
-* safe_voltage_status
-* battery_charge
-* battery_load
-* current_value
-* est_run_time
-* power_value
-* voltage_value
 
-Master switch will turn on / off all the switches that the physical switch on the box does. You can config that through the UI on the wattbox directly. If ALL of the switches controlled by Master are on, then Master will be on. Otherwise it will be off.
+- audible_alarm
+- auto_reboot
+- battery_health
+- battery_test
+- cloud_status
+- has_ups
+- mute
+- power_lost
+- safe_voltage_status
+- battery_charge
+- battery_load
+- current_value
+- est_run_time
+- power_value
+- voltage_value
 
-Be careful, if the WattBox controls the power to its own networking equipment you can turn it off and not have remote access until you fix it. You may even have to plug it in elsewhere to get back online and turn that outlet back on in HA.
+Be careful, if the WattBox controls the power to its own networking equipment you can turn it off and not have remote access until you fix it. You may even have to plug it in elsewhere to get back online and turn that outlet back on in HA. Use the _skip_regexp_ option for those outlets.
+
+Master switch will turn on / off all the switches that the physical switch on the box does. You can config that through the UI on the wattbox directly. If ALL of the switches controlled by Master are on, then Master will be on. Otherwise it will be off. If any outlets on a wattbox are skipped via _skip_regexp_ then
+the master switch for that wattbox will also not be added as an entity.
+
+You can use
 
 Based on [custom-components/integration_blueprint][blueprint]
 
 <!---->
 
-***
+---
 
 [wattbox]: https://www.snapav.com/shop/en/snapav/wattbox
 [hacs]: https://hacs.xyz/

--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -41,6 +41,8 @@ from .const import (
     SENSOR_TYPES,
     STARTUP,
     TOPIC_UPDATE,
+    CONF_NAME_REGEXP,
+    CONF_SKIP_REGEXP
 )
 
 REQUIREMENTS: Final[List[str]] = ["pywattbox>=0.4.0"]
@@ -49,6 +51,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ALL_SENSOR_TYPES: Final[List[str]] = [*BINARY_SENSOR_TYPES.keys(), *SENSOR_TYPES.keys()]
 
+
 WATTBOX_HOST_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): cv.string,
@@ -56,6 +59,8 @@ WATTBOX_HOST_SCHEMA = vol.Schema(
         vol.Optional(CONF_USERNAME, default=DEFAULT_USER): cv.string,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME_REGEXP): cv.string,
+        vol.Optional(CONF_SKIP_REGEXP): cv.string,
         vol.Optional(CONF_RESOURCES, default=ALL_SENSOR_TYPES): vol.All(
             cv.ensure_list, [vol.In(ALL_SENSOR_TYPES)]
         ),
@@ -93,10 +98,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         port = wattbox_host.get(CONF_PORT)
         username = wattbox_host.get(CONF_USERNAME)
         name = wattbox_host.get(CONF_NAME)
+        name_regexp = wattbox_host.get(CONF_NAME_REGEXP)
+        skip_regexp = wattbox_host.get(CONF_SKIP_REGEXP)
 
-        hass.data[DOMAIN_DATA][name] = await hass.async_add_executor_job(
+        wattbox = await hass.async_add_executor_job(
             WattBox, host, port, username, password
         )
+        hass.data[DOMAIN_DATA][name] = { "wattbox": wattbox, "name_regexp": name_regexp, "skip_regexp": skip_regexp }
 
         # Load platforms
         for platform in PLATFORMS:
@@ -115,8 +123,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # Extra logging to ensure the right outlets are set up.
     _LOGGER.debug(", ".join([str(v) for _, v in hass.data[DOMAIN_DATA].items()]))
     _LOGGER.debug(repr(hass.data[DOMAIN_DATA]))
-    for _, wattbox in hass.data[DOMAIN_DATA].items():
-        _LOGGER.debug("%s has %s outlets", wattbox, len(wattbox.outlets))
+    for _, state in hass.data[DOMAIN_DATA].items():
+        wattbox = state['wattbox']
+        _LOGGER.debug("%s has %s outlets%s", wattbox, len(wattbox.outlets))
         for outlet in wattbox.outlets:
             _LOGGER.debug("Outlet: %s - %s", outlet, repr(outlet))
 
@@ -128,11 +137,12 @@ async def update_data(_: datetime, hass: HomeAssistant, name: str) -> None:
 
     # This is where the main logic to update platform data goes.
     try:
-        await hass.async_add_executor_job(hass.data[DOMAIN_DATA][name].update)
+        wattbox = hass.data[DOMAIN_DATA][name]['wattbox']
+        await hass.async_add_executor_job(wattbox.update)
         _LOGGER.debug(
             "Updated: %s - %s",
-            hass.data[DOMAIN_DATA][name],
-            repr(hass.data[DOMAIN_DATA][name]),
+            wattbox,
+            repr(wattbox),
         )
         # Send update to topic for entities to see
         async_dispatcher_send(hass, TOPIC_UPDATE.format(DOMAIN, name))

--- a/custom_components/wattbox/binary_sensor.py
+++ b/custom_components/wattbox/binary_sensor.py
@@ -44,14 +44,13 @@ class WattBoxBinarySensor(WattBoxEntity, BinarySensorEntity):
         self.flipped: bool = BINARY_SENSOR_TYPES[self.type]["flipped"]
         self._attr_name = name + " " + BINARY_SENSOR_TYPES[sensor_type]["name"]
         self._attr_device_class = BINARY_SENSOR_TYPES[self.type]["device_class"]
+        self._wattbox =  self.hass.data[DOMAIN_DATA][self.wattbox_name]['wattbox']
+        self._attr_unique_id = '{}-bsensor-{}'.format(self._wattbox.serial_number, sensor_type)
 
     async def async_update(self) -> None:
         """Update the sensor."""
-        # Get domain data
-        wattbox = self.hass.data[DOMAIN_DATA][self.wattbox_name]
-
         # Check the data and update the value.
-        value: bool | None = getattr(wattbox, self.type)
+        value: bool | None = getattr(self._wattbox, self.type)
         if value is not None and self.flipped:
             value = not value
         self._attr_is_on = value

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
-VERSION: Final[str] = "0.8.1"
+VERSION: Final[str] = "0.9.0"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
 REQUIRED_FILES: Final[List[str]] = [
     "binary_sensor.py",
@@ -48,6 +48,10 @@ DEFAULT_USER: Final[str] = DOMAIN
 DEFAULT_SCAN_INTERVAL: Final[timedelta] = timedelta(seconds=30)
 
 TOPIC_UPDATE: Final[str] = "{}_data_update_{}"
+
+# config options
+CONF_NAME_REGEXP: Final[str] = 'name_regexp'
+CONF_SKIP_REGEXP: Final[str] = 'skip_regexp'
 
 
 class _BinarySensorDict(TypedDict):

--- a/custom_components/wattbox/manifest.json
+++ b/custom_components/wattbox/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "wattbox",
     "name": "WattBox",
-    "version": "0.8.0",
+    "version": "0.9.0",
     "issue_tracker": "https://github.com/eseglem/hass-wattbox/issues",
     "documentation": "https://github.com/eseglem/hass-wattbox",
     "dependencies": [],

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -44,11 +44,11 @@ class WattBoxSensor(WattBoxEntity):
         self._attr_name = name + " " + SENSOR_TYPES[self.sensor_type]["name"]
         self._attr_unit_of_measurement = SENSOR_TYPES[self.sensor_type]["unit"]
         self._attr_icon = SENSOR_TYPES[self.sensor_type]["icon"]
+        self._wattbox =  self.hass.data[DOMAIN_DATA][self.wattbox_name]['wattbox']
+        self._attr_unique_id = '{}-sensor-{}'.format(self._wattbox.serial_number, sensor_type)
 
     async def async_update(self) -> None:
         """Update the sensor."""
         # Get new data (if any)
-        wattbox = self.hass.data[DOMAIN_DATA][self.wattbox_name]
-
         # Check the data and update the value.
-        self._attr_state = getattr(wattbox, self.sensor_type, STATE_UNKNOWN)
+        self._attr_state = getattr(self._wattbox, self.sensor_type, STATE_UNKNOWN)

--- a/custom_components/wattbox/switch.py
+++ b/custom_components/wattbox/switch.py
@@ -1,6 +1,7 @@
 """Switch platform for wattbox."""
 
 import logging
+import re
 from typing import Final, List
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
@@ -9,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import DOMAIN_DATA, PLUG_ICON
+from .const import DOMAIN_DATA, PLUG_ICON, CONF_NAME_REGEXP, CONF_SKIP_REGEXP
 from .entity import WattBoxEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,12 +25,52 @@ async def async_setup_platform(  # pylint: disable=unused-argument
     """Setup switch platform."""
     name: str = discovery_info[CONF_NAME]
     entities: List[WattBoxEntity] = []
+    config = hass.data[DOMAIN_DATA][name]
+    wattbox = config['wattbox']
+    name_regexp_str = config[CONF_NAME_REGEXP]
+    skip_regexp_str = config[CONF_SKIP_REGEXP]
+    num_switches: int = wattbox.number_outlets
+    name_regexp = None
+    try:
+        if name_regexp_str:
+            name_regexp = re.compile(name_regexp_str)
+    except re.error as err:
+        _LOGGER.error("Invalid name_regexp: %s", name_regexp_str)
 
-    num_switches: int = hass.data[DOMAIN_DATA][name].number_outlets
+    skip_regexp = None
+    try:
+        if skip_regexp_str:
+            skip_regexp = re.compile(skip_regexp_str)
+    except re.error as err:
+        _LOGGER.error("Invalid skip_regexp: %s", skip_regexp_str)
 
-    entities.append(WattBoxMasterSwitch(hass, name))
+    skipped_an_outlet = False
     for i in range(1, num_switches + 1):
-        entities.append(WattBoxBinarySwitch(hass, name, i))
+        outlet_name = None
+        outlet_full_name = wattbox.outlets[i].name
+
+        if skip_regexp and skip_regexp.search(outlet_full_name):
+            _LOGGER.debug("Skipping switch #%s - %s", i, outlet_full_name)
+            skipped_an_outlet = True
+            continue
+        if name_regexp:
+            outlet_name = outlet_full_name
+            matched = name_regexp.search(outlet_full_name)
+            if matched:
+                outlet_name = matched.group()
+                try:
+                    if matched.group(1) != None and matched.group(1) != '':
+                        outlet_name  = matched.group(1)
+                except:
+                    pass
+        _LOGGER.debug("Adding switch #%s - %s", i, outlet_name)
+        entities.append(WattBoxBinarySwitch(hass, name, i, outlet_name))
+
+    # skip the master switch iff any of the outlets are skipped
+    if not skipped_an_outlet:
+        entities.append(WattBoxMasterSwitch(hass, name))
+    else:
+        _LOGGER.debug("Skipping master switch because an outlet was skipped for %s", name)
 
     async_add_entities(entities, True)
 
@@ -39,15 +80,20 @@ class WattBoxBinarySwitch(WattBoxEntity, SwitchEntity):
 
     _attr_device_class: Final[str] = SwitchDeviceClass.OUTLET
 
-    def __init__(self, hass: HomeAssistant, name: str, index: int):
+    def __init__(self, hass: HomeAssistant, name: str, index: int, outlet_name: str = None):
         super().__init__(hass, name, index)
         self.index: int = index
-        self._attr_name = name + " Outlet " + str(index)
+        if outlet_name and outlet_name.strip() != '':
+            self._attr_name = name + " " + outlet_name.strip()
+        else:
+            self._attr_name = name + " Outlet " + str(index)
+        self._wattbox =  self.hass.data[DOMAIN_DATA][self.wattbox_name]['wattbox']
+        self._attr_unique_id = '{}-switch-{}'.format(self._wattbox.serial_number, index)
 
     async def async_update(self):
         """Update the sensor."""
         # Get new data (if any)
-        outlet = self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index]
+        outlet = self._wattbox.outlets[self.index]
 
         # Check the data and update the value.
         self._attr_is_on = outlet.status
@@ -61,40 +107,40 @@ class WattBoxBinarySwitch(WattBoxEntity, SwitchEntity):
         """Turn on the switch."""
         _LOGGER.debug(
             "Turning On: %s - %s",
-            self.hass.data[DOMAIN_DATA][self.wattbox_name],
-            self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index],
+            self._wattbox,
+            self._wattbox.outlets[self.index],
         )
         _LOGGER.debug(
             "Current Outlet Before: %s - %s",
-            self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index].status,
-            repr(self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index]),
+            self._wattbox.outlets[self.index].status,
+            repr(self._wattbox.outlets[self.index]),
         )
         # Update state first so it is not stale.
         self._attr_is_on = True
         self.async_write_ha_state()
         # Trigger the action on the wattbox.
         await self.hass.async_add_executor_job(
-            self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index].turn_on
+            self._wattbox.outlets[self.index].turn_on
         )
 
     async def async_turn_off(self, **kwargs) -> None:  # pylint: disable=unused-argument
         """Turn off the switch."""
         _LOGGER.debug(
             "Turning Off: %s - %s",
-            self.hass.data[DOMAIN_DATA][self.wattbox_name],
-            self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index],
+            self._wattbox,
+            self._wattbox.outlets[self.index],
         )
         _LOGGER.debug(
             "Current Outlet Before: %s - %s",
-            self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index].status,
-            repr(self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index]),
+            self._wattbox.outlets[self.index].status,
+            repr(self._wattbox.outlets[self.index]),
         )
         # Update state first so it is not stale.
         self._attr_is_on = False
         self.async_write_ha_state()
         # Trigger the action on the wattbox.
         await self.hass.async_add_executor_job(
-            self.hass.data[DOMAIN_DATA][self.wattbox_name].outlets[self.index].turn_off
+            self._wattbox.outlets[self.index].turn_off
         )
 
     @property
@@ -102,10 +148,11 @@ class WattBoxBinarySwitch(WattBoxEntity, SwitchEntity):
         """Return the icon of this switch."""
         return PLUG_ICON
 
-
 class WattBoxMasterSwitch(WattBoxBinarySwitch):
     """WattBox master switch class."""
 
     def __init__(self, hass: HomeAssistant, name: str) -> None:
         super().__init__(hass, name, 0)
         self._attr_name = name + " Master Switch"
+        self._wattbox =  self.hass.data[DOMAIN_DATA][self.wattbox_name]['wattbox']
+        self._attr_unique_id = '{}-switch-master'.format(self._wattbox.serial_number)


### PR DESCRIPTION
…extract a default entity_id name based on the outlet name) and skip_regexp (a predicate test on whether to skip creating an entity for the outlet, e.g., for outlets that you really do not want to accidentally control like those with networking gear plugged into it).  Bump to 0.9.0