### PR TITLE
Create reset button for wattbox.

### DIFF
--- a/custom_components/wattbox/button.py
+++ b/custom_components/wattbox/button.py
@@ -1,0 +1,121 @@
+"""Button platform for wattbox."""
+
+import logging
+import re
+from typing import Any, List
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.const import CONF_NAME, EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from pywattbox.base import BaseWattBox, Outlet
+
+from .const import (
+    CONF_NAME_REGEXP,
+    CONF_SKIP_REGEXP,
+    DOMAIN_DATA,
+    RESTART_ICON,
+)
+from .entity import WattBoxEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def validate_regex(config: ConfigType, key: str) -> re.Pattern[str] | None:
+    regexp_str: str = config.get(key, "")
+    if regexp_str:
+        try:
+            return re.compile(regexp_str)
+        except re.error:
+            _LOGGER.error("Invalid %s: %s", key, regexp_str)
+    return None
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType,
+) -> None:
+    """Setup button platform."""
+    name: str = discovery_info[CONF_NAME]
+
+    entities: List[WattBoxEntity] = []
+    wattbox: BaseWattBox = hass.data[DOMAIN_DATA][name]
+
+    name_regexp = validate_regex(config, CONF_NAME_REGEXP)
+    skip_regexp = validate_regex(config, CONF_SKIP_REGEXP)
+
+    # Add index 0 master outlet
+    entities.append(WattBoxResetButton(hass, name, 0, f"Master"))
+    for i, outlet in wattbox.outlets.items():
+        outlet_name = outlet.name or ""
+
+        # Skip outlets if they match regex
+        if skip_regexp and skip_regexp.search(outlet_name):
+            _LOGGER.debug("Skipping outlet #%s - %s", i, outlet_name)
+            continue
+
+        if name_regexp:
+            if matched := name_regexp.search(outlet_name):
+                outlet_name = matched.group()
+                try:
+                    outlet_name = matched.group(1)
+                except re.error:
+                    pass
+
+        _LOGGER.debug("Adding outlet reset #%s - %s", i, outlet_name)
+        entities.append(WattBoxResetButton(hass, name, i, outlet_name))
+
+    async_add_entities(entities)
+
+
+class WattBoxResetButton(WattBoxEntity, ButtonEntity):
+    """WattBox reset button class."""
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_should_poll = False
+    _outlet: Outlet
+
+    def __init__(
+        self, hass: HomeAssistant, name: str, index: int, outlet_name: str = ""
+    ) -> None:
+        super().__init__(hass, name, index)
+        # Master Outlet (index == 0) is not in the oulets dict
+        if index:
+            self._outlet = self._wattbox.outlets[index]
+        else:
+            self._outlet = self._wattbox.master_outlet
+        # Determine outlet name
+        if outlet_name := outlet_name.strip():
+            self._attr_name = f"{name} {outlet_name} Reset"
+        else:
+            self._attr_name = f"{name} Outlet {index} Reset"
+        self._attr_unique_id = f"{self._wattbox.serial_number}-button-reset-{index}"
+
+    async def async_update(self) -> None:
+        """Update the sensor."""
+        # Set/update attributes
+        self._attr_extra_state_attributes["name"] = self._outlet.name
+        self._attr_extra_state_attributes["method"] = self._outlet.method
+        self._attr_extra_state_attributes["index"] = self._outlet.index
+
+    async def async_press(self) -> None:
+        """Issue a reset to the outlet."""
+        _LOGGER.debug("Resetting On: %s - %s", self._wattbox, self._outlet)
+        # Trigger the action on the wattbox.
+        await self._outlet.async_reset()
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon of this button."""
+        return RESTART_ICON
+
+    @property
+    def device_class(self) -> str:
+        return ButtonDeviceClass.RESTART
+
+    @property
+    def entity_category(self):
+        return EntityCategory.CONFIG

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -5,17 +5,17 @@ from typing import Dict, Final, List, TypedDict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
+    UnitOfElectricPotential,
     PERCENTAGE,
-    POWER_WATT,
-    TIME_MINUTES,
+    UnitOfPower,
+    UnitOfTime,
 )
 
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
 VERSION: Final[str] = "0.9.0"
-PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
+PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch", "button"]
 ISSUE_URL: Final[str] = "https://github.com/eseglem/hass-wattbox/issues"
 
 STARTUP: Final[
@@ -33,6 +33,7 @@ If you have any issues with this you need to open an issue here:
 # Icons
 ICON: Final[str] = "mdi:power"
 PLUG_ICON: Final[str] = "mdi:power-socket-us"
+RESTART_ICON: Final[str] = "mdi:restart"
 
 # Defaults
 DEFAULT_NAME: Final[str] = "WattBox"
@@ -105,17 +106,17 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
     "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
     "est_run_time": {
         "name": "Estimated Run Time",
-        "unit": TIME_MINUTES,
+        "unit": UnitOfTime.MINUTES,
         "icon": "mdi:timer",
     },
     "power_value": {
         "name": "Power",
-        "unit": POWER_WATT,
+        "unit": UnitOfPower.WATT,
         "icon": "mdi:lightbulb-outline",
     },
     "voltage_value": {
         "name": "Voltage",
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT ,
         "icon": "mdi:lightning-bolt-circle",
     },
 }


### PR DESCRIPTION
This updates the constants and supports a new button type meant for issuing the reset command inside of pywattbox.

I dusted off a wattbox and found that it was easier to control the reset case than it was the on/off case. If you couple this with some of the OutletModeSet commands you can ensure you have a reliable system. This does add a lot more entities as a result, I included a master reset as well. Since you can control the timing with OutletPowerOnDelaySet, I figured there was no point in modifying pywattbox yet.

Only noted errors were `detected blocking call to import_module inside` scrapli and the `open` in ctypes which are both fixable downstream in pywattbox. I fixed the others home assistant issues with this change.