### PR TITLE
fix IntegrationSensor based on recent HA changes

### DIFF
--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -37,10 +37,11 @@ async def async_setup_platform(
     entities.append(
         IntegrationSensor(
             integration_method="trapezoidal",
-            name=f"{name}_energy_spent",
+            name=f"{name} Total Energy",
             round_digits=2,
-            source_entity=f"sensor.{name}_power",
-            unique_id=None,
+            max_sub_interval=timedelta(minutes = 5),
+            source_entity=f"sensor.{name}_power".replace(' ','_').lower(),
+            unique_id=f"{name}_total_energy".replace(' ','_').lower(),
             unit_prefix="k",
             unit_time=UnitOfTime.HOURS,
         )


### PR DESCRIPTION
Small change that gets previously-added Integration sensor (for total power of the Wattbox) working with recent HA builts:
* Renames the sensor to "Total Energy."
* Adds the (seemingly required, although the docs say optional) `max_sub_interval` parameter, which is actually good for Wattboxes that don't report changes in power very frequently. 
* Sets the above to 5 minutes intervals.
* Handles Wattbox instances with names that include spaces (lines 44 and 45)