### PR TITLE
Migrate to Config Flow

### DIFF
--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -9,14 +9,11 @@ from datetime import datetime
 from functools import partial
 from typing import Final, List
 
-import homeassistant.helpers.config_validation as cv
-import voluptuous as vol
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
-    CONF_RESOURCES,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
@@ -28,18 +25,9 @@ from homeassistant.helpers.typing import ConfigType
 from pywattbox.base import BaseWattBox
 
 from .const import (
-    BINARY_SENSOR_TYPES,
-    CONF_NAME_REGEXP,
-    CONF_SKIP_REGEXP,
-    DEFAULT_NAME,
-    DEFAULT_PASSWORD,
-    DEFAULT_PORT,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_USER,
     DOMAIN,
     DOMAIN_DATA,
     PLATFORMS,
-    SENSOR_TYPES,
     STARTUP,
     TOPIC_UPDATE,
 )
@@ -47,31 +35,6 @@ from .const import (
 REQUIREMENTS: Final[List[str]] = ["pywattbox>=0.7.2"]
 
 _LOGGER = logging.getLogger(__name__)
-
-ALL_SENSOR_TYPES: Final[List[str]] = [*BINARY_SENSOR_TYPES.keys(), *SENSOR_TYPES.keys()]
-
-WATTBOX_HOST_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
-        vol.Optional(CONF_USERNAME, default=DEFAULT_USER): cv.string,
-        vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_NAME_REGEXP): cv.string,
-        vol.Optional(CONF_SKIP_REGEXP): cv.string,
-        vol.Optional(CONF_RESOURCES, default=ALL_SENSOR_TYPES): vol.All(
-            cv.ensure_list, [vol.In(ALL_SENSOR_TYPES)]
-        ),
-        vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): cv.time_period,
-    }
-)
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(cv.ensure_list, [WATTBOX_HOST_SCHEMA]),
-    },
-    extra=vol.ALLOW_EXTRA,
-)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/wattbox/config_flow.py
+++ b/custom_components/wattbox/config_flow.py
@@ -1,0 +1,72 @@
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_RESOURCES,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
+
+from .const import (
+    ALL_SENSOR_TYPES,
+    CONF_NAME_REGEXP,
+    CONF_SKIP_REGEXP,
+    DEFAULT_NAME,
+    DEFAULT_PASSWORD,
+    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_USER,
+    DOMAIN,
+)
+
+WATTBOX_HOST_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+        vol.Optional(CONF_USERNAME, default=DEFAULT_USER): cv.string,
+        vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_NAME_REGEXP): cv.string,
+        vol.Optional(CONF_SKIP_REGEXP): cv.string,
+        vol.Optional(CONF_RESOURCES, default=ALL_SENSOR_TYPES): vol.All(
+            cv.ensure_list, [vol.In(ALL_SENSOR_TYPES)]
+        ),
+        vol.Optional(
+            CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+        ): cv.positive_time_period,
+    }
+)
+
+
+class WattboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Wattbox config flow v1."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"Wattbox: {user_input[CONF_NAME]}",
+                data=user_input,
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=WATTBOX_HOST_SCHEMA,
+            errors=errors,
+        )
+
+
+# Config Flow migration information for future reference:
+# https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#config-entry-migration

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
-VERSION: Final[str] = "0.9.0"
+VERSION: Final[str] = "0.9.1"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
 ISSUE_URL: Final[str] = "https://github.com/eseglem/hass-wattbox/issues"
 
@@ -119,3 +119,5 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
         "icon": "mdi:lightning-bolt-circle",
     },
 }
+
+ALL_SENSOR_TYPES: Final[List[str]] = [*BINARY_SENSOR_TYPES.keys(), *SENSOR_TYPES.keys()]

--- a/custom_components/wattbox/manifest.json
+++ b/custom_components/wattbox/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": [
     "@eseglem"
   ],
+  "config_flow": true,
   "dependencies": [
     "network",
     "integration"
@@ -22,5 +23,5 @@
   "requirements": [
     "pywattbox[http,ip]==0.7.2"
   ],
-  "version": "0.9.0"
+  "version": "0.9.1"
 }


### PR DESCRIPTION
Started migrating to config flow a while back, putting this here for reference. It doesn't look like I got very far with it, and it will definitely need to be checked against the latest HA dev docs.

The intent was to set it up so there is a choice of HTTP v Telnet to start, and list the models known to use each. Making it so the end user doesn't actually need to set the port numbers and such.

#12 