### PR TITLE
Replace deprecated constants with enumerators

### DIFF
--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -43,7 +43,7 @@ from .const import (
     TOPIC_UPDATE,
 )
 
-REQUIREMENTS: Final[List[str]] = ["pywattbox>=0.4.0"]
+REQUIREMENTS: Final[List[str]] = ["pywattbox>=0.4.0,<0.7.0"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -5,10 +5,10 @@ from typing import Dict, Final, List, TypedDict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
+    UnitOfElectricPotential,
     PERCENTAGE,
-    POWER_WATT,
-    TIME_MINUTES,
+    UnitOfPower,
+    UnitOfTime,
 )
 
 # Base component constants
@@ -107,17 +107,17 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
     "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
     "est_run_time": {
         "name": "Estimated Run Time",
-        "unit": TIME_MINUTES,
+        "unit": UnitOfTime.MINUTES,
         "icon": "mdi:timer",
     },
     "power_value": {
         "name": "Power",
-        "unit": POWER_WATT,
+        "unit": UnitOfPower.WATT,
         "icon": "mdi:lightbulb-outline",
     },
     "voltage_value": {
         "name": "Voltage",
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "icon": "mdi:lightning-bolt-circle",
     },
 }

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
-VERSION: Final[str] = "0.8.1"
+VERSION: Final[str] = "0.8.2"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
 REQUIRED_FILES: Final[List[str]] = [
     "binary_sensor.py",

--- a/custom_components/wattbox/manifest.json
+++ b/custom_components/wattbox/manifest.json
@@ -10,6 +10,6 @@
         "@eseglem"
     ],
     "requirements": [
-        "pywattbox>=0.4.0"
+        "pywattbox>=0.4.0,<0.7.0"
     ]
 }


### PR DESCRIPTION
Replaces deprecated and removed constants with the recommended enumerators: https://developers.home-assistant.io/blog/2022/12/05/more-unit-enumerators/.

Resolves https://github.com/eseglem/hass-wattbox/issues/20