### PR TITLE
Add try blocks to support PlatformNotReady

### DIFF
--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -25,7 +25,6 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.exceptions import PlatformNotReady
 from pywattbox.base import BaseWattBox
 
 from .const import (
@@ -96,23 +95,17 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             from pywattbox.ip_wattbox import async_create_ip_wattbox
 
             _LOGGER.debug("Creating IP WattBox")
-            try:
-                wattbox = await async_create_ip_wattbox(
-                    host=host, user=username, password=password, port=port
-                )
-            except ConnectionError as ex:
-                raise PlatformNotReady(f"Connection error while connecting to {host}: {ex}") from ex
+            wattbox = await async_create_ip_wattbox(
+                host=host, user=username, password=password, port=port
+            )
         else:
             _LOGGER.debug("Importing HTTP Wattbox")
             from pywattbox.http_wattbox import async_create_http_wattbox
 
             _LOGGER.debug("Creating HTTP WattBox")
-            try:
-                wattbox = await async_create_http_wattbox(
-                    host=host, user=username, password=password, port=port
-                )
-            except ConnectionError as ex:
-                raise PlatformNotReady(f"Connection error while connecting to {host}: {ex}") from ex
+            wattbox = await async_create_http_wattbox(
+                host=host, user=username, password=password, port=port
+            )
         hass.data[DOMAIN_DATA][name] = wattbox
 
         # Load platforms

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -5,17 +5,18 @@ from typing import Dict, Final, List, TypedDict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
+    UnitOfElectricPotential,
+    UnitOfElectricCurrent,
     PERCENTAGE,
-    POWER_WATT,
-    TIME_MINUTES,
+    UnitOfPower,
+    UnitOfTime,
 )
 
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
 VERSION: Final[str] = "0.9.0"
-PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
+PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch", "button"]
 ISSUE_URL: Final[str] = "https://github.com/eseglem/hass-wattbox/issues"
 
 STARTUP: Final[
@@ -33,6 +34,7 @@ If you have any issues with this you need to open an issue here:
 # Icons
 ICON: Final[str] = "mdi:power"
 PLUG_ICON: Final[str] = "mdi:power-socket-us"
+RESTART_ICON: Final[str] = "mdi:restart"
 
 # Defaults
 DEFAULT_NAME: Final[str] = "WattBox"
@@ -102,20 +104,24 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
         "icon": "mdi:battery",
     },
     "battery_load": {"name": "Battery Load", "unit": PERCENTAGE, "icon": "mdi:gauge"},
-    "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
+    "current_value": {
+        "name": "Current",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "icon": "mdi:current-ac",
+    },
     "est_run_time": {
         "name": "Estimated Run Time",
-        "unit": TIME_MINUTES,
+        "unit": UnitOfTime.MINUTES,
         "icon": "mdi:timer",
     },
     "power_value": {
         "name": "Power",
-        "unit": POWER_WATT,
+        "unit": UnitOfPower.WATT,
         "icon": "mdi:lightbulb-outline",
     },
     "voltage_value": {
         "name": "Voltage",
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "icon": "mdi:lightning-bolt-circle",
     },
 }

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -5,17 +5,23 @@ from typing import Dict, Final, List, TypedDict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
+    UnitOfElectricPotential,
     PERCENTAGE,
-    POWER_WATT,
-    TIME_MINUTES,
+    UnitOfPower,
+    UnitOfTime,
 )
 
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
-VERSION: Final[str] = "0.9.0"
+VERSION: Final[str] = "0.8.2"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
+REQUIRED_FILES: Final[List[str]] = [
+    "binary_sensor.py",
+    "const.py",
+    "sensor.py",
+    "switch.py",
+]
 ISSUE_URL: Final[str] = "https://github.com/eseglem/hass-wattbox/issues"
 
 STARTUP: Final[
@@ -42,10 +48,6 @@ DEFAULT_USER: Final[str] = DOMAIN
 DEFAULT_SCAN_INTERVAL: Final[timedelta] = timedelta(seconds=30)
 
 TOPIC_UPDATE: Final[str] = "{}_data_update_{}"
-
-# config options
-CONF_NAME_REGEXP: Final[str] = "name_regexp"
-CONF_SKIP_REGEXP: Final[str] = "skip_regexp"
 
 
 class _BinarySensorDict(TypedDict):
@@ -105,17 +107,17 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
     "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
     "est_run_time": {
         "name": "Estimated Run Time",
-        "unit": TIME_MINUTES,
+        "unit": UnitOfTime.MINUTES,
         "icon": "mdi:timer",
     },
     "power_value": {
         "name": "Power",
-        "unit": POWER_WATT,
+        "unit": UnitOfPower.WATT,
         "icon": "mdi:lightbulb-outline",
     },
     "voltage_value": {
         "name": "Voltage",
-        "unit": ELECTRIC_POTENTIAL_VOLT,
+        "unit": UnitOfElectricPotential.VOLT,
         "icon": "mdi:lightning-bolt-circle",
     },
 }

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
-VERSION: Final[str] = "0.9"
+VERSION: Final[str] = "0.9.0"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
 REQUIRED_FILES: Final[List[str]] = [
     "binary_sensor.py",

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -6,6 +6,7 @@ from typing import Dict, Final, List, TypedDict
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
     UnitOfElectricPotential,
+    UnitOfElectricCurrent,
     PERCENTAGE,
     UnitOfPower,
     UnitOfTime,
@@ -16,12 +17,6 @@ DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
 VERSION: Final[str] = "0.9.0"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
-REQUIRED_FILES: Final[List[str]] = [
-    "binary_sensor.py",
-    "const.py",
-    "sensor.py",
-    "switch.py",
-]
 ISSUE_URL: Final[str] = "https://github.com/eseglem/hass-wattbox/issues"
 
 STARTUP: Final[
@@ -39,6 +34,7 @@ If you have any issues with this you need to open an issue here:
 # Icons
 ICON: Final[str] = "mdi:power"
 PLUG_ICON: Final[str] = "mdi:power-socket-us"
+RESTART_ICON: Final[str] = "mdi:restart"
 
 # Defaults
 DEFAULT_NAME: Final[str] = "WattBox"
@@ -48,6 +44,10 @@ DEFAULT_USER: Final[str] = DOMAIN
 DEFAULT_SCAN_INTERVAL: Final[timedelta] = timedelta(seconds=30)
 
 TOPIC_UPDATE: Final[str] = "{}_data_update_{}"
+
+# config options
+CONF_NAME_REGEXP: Final[str] = "name_regexp"
+CONF_SKIP_REGEXP: Final[str] = "skip_regexp"
 
 
 class _BinarySensorDict(TypedDict):
@@ -104,7 +104,11 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
         "icon": "mdi:battery",
     },
     "battery_load": {"name": "Battery Load", "unit": PERCENTAGE, "icon": "mdi:gauge"},
-    "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
+    "current_value": {
+        "name": "Current",
+        "unit": UnitOfElectricCurrent.AMPERE,
+        "icon": "mdi:current-ac",
+    },
     "est_run_time": {
         "name": "Estimated Run Time",
         "unit": UnitOfTime.MINUTES,

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -5,18 +5,17 @@ from typing import Dict, Final, List, TypedDict
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import (
-    UnitOfElectricPotential,
-    UnitOfElectricCurrent,
+    ELECTRIC_POTENTIAL_VOLT,
     PERCENTAGE,
-    UnitOfPower,
-    UnitOfTime,
+    POWER_WATT,
+    TIME_MINUTES,
 )
 
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
 VERSION: Final[str] = "0.9.0"
-PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch", "button"]
+PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
 ISSUE_URL: Final[str] = "https://github.com/eseglem/hass-wattbox/issues"
 
 STARTUP: Final[
@@ -34,7 +33,6 @@ If you have any issues with this you need to open an issue here:
 # Icons
 ICON: Final[str] = "mdi:power"
 PLUG_ICON: Final[str] = "mdi:power-socket-us"
-RESTART_ICON: Final[str] = "mdi:restart"
 
 # Defaults
 DEFAULT_NAME: Final[str] = "WattBox"
@@ -104,24 +102,20 @@ SENSOR_TYPES: Final[Dict[str, _SensorTypeDict]] = {
         "icon": "mdi:battery",
     },
     "battery_load": {"name": "Battery Load", "unit": PERCENTAGE, "icon": "mdi:gauge"},
-    "current_value": {
-        "name": "Current",
-        "unit": UnitOfElectricCurrent.AMPERE,
-        "icon": "mdi:current-ac",
-    },
+    "current_value": {"name": "Current", "unit": "A", "icon": "mdi:current-ac"},
     "est_run_time": {
         "name": "Estimated Run Time",
-        "unit": UnitOfTime.MINUTES,
+        "unit": TIME_MINUTES,
         "icon": "mdi:timer",
     },
     "power_value": {
         "name": "Power",
-        "unit": UnitOfPower.WATT,
+        "unit": POWER_WATT,
         "icon": "mdi:lightbulb-outline",
     },
     "voltage_value": {
         "name": "Voltage",
-        "unit": UnitOfElectricPotential.VOLT,
+        "unit": ELECTRIC_POTENTIAL_VOLT,
         "icon": "mdi:lightning-bolt-circle",
     },
 }

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
 # Base component constants
 DOMAIN: Final[str] = "wattbox"
 DOMAIN_DATA: Final[str] = f"{DOMAIN}_data"
-VERSION: Final[str] = "0.8.2"
+VERSION: Final[str] = "0.9"
 PLATFORMS: Final[List[str]] = ["binary_sensor", "sensor", "switch"]
 REQUIRED_FILES: Final[List[str]] = [
     "binary_sensor.py",

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import List, Union
+from asyncio import TimeoutError, wait_for
 
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.sensor import SensorEntity
@@ -9,6 +10,7 @@ from homeassistant.const import CONF_NAME, CONF_RESOURCES, STATE_UNKNOWN, UnitOf
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.exceptions import PlatformNotReady
 
 from .const import SENSOR_TYPES
 from .entity import WattBoxEntity
@@ -23,32 +25,41 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType,
 ) -> None:
     """Setup sensor platform."""
-    conf_name: str = discovery_info[CONF_NAME]
-    clean_name = conf_name.replace(" ", "_").lower()
-    entities: List[Union[WattBoxSensor, IntegrationSensor]] = []
+    try:
+        conf_name: str = discovery_info[CONF_NAME]
+        clean_name = conf_name.replace(" ", "_").lower()
+        entities: List[Union[WattBoxSensor, IntegrationSensor]] = []
 
-    resource: str
-    for resource in discovery_info[CONF_RESOURCES]:
-        if (sensor_type := resource.lower()) not in SENSOR_TYPES:
-            continue
-        entities.append(WattBoxSensor(hass, conf_name, sensor_type))
+        resource: str
+        for resource in discovery_info[CONF_RESOURCES]:
+            if (sensor_type := resource.lower()) not in SENSOR_TYPES:
+                continue
 
-    # TODO: Add a setting for this, default to true?
-    # Add an IntegrationSensor, so end users don't have to manually configure it.
-    entities.append(
-        IntegrationSensor(
-            integration_method="trapezoidal",
-            name=f"{conf_name} Total Energy",
-            round_digits=2,
-            max_sub_interval=timedelta(minutes=5),
-            source_entity=f"sensor.{clean_name}_power",
-            unique_id=f"{clean_name}_total_energy",
-            unit_prefix="k",
-            unit_time=UnitOfTime.HOURS,
+            try:
+                entities.append(WattBoxSensor(hass, conf_name, sensor_type))
+            except Exception as err:
+                _LOGGER.error("Failed to append WattBoxSensor: %s", err)
+                raise PlatformNotReady from err
+
+        # TODO: Add a setting for this, default to true?
+        # Add an IntegrationSensor, so end users don't have to manually configure it.
+        entities.append(
+            IntegrationSensor(
+                integration_method="trapezoidal",
+                name=f"{conf_name} Total Energy",
+                round_digits=2,
+                max_sub_interval=timedelta(minutes=5),
+                source_entity=f"sensor.{clean_name}_power",
+                unique_id=f"{clean_name}_total_energy",
+                unit_prefix="k",
+                unit_time=UnitOfTime.HOURS,
+            )
         )
-    )
 
-    async_add_entities(entities)
+        await async_add_entities(entities)
+    except Exception as err:
+        _LOGGER.error("Error setting up sensor platform: %s", err)
+        raise PlatformNotReady from err
 
 
 class WattBoxSensor(WattBoxEntity, SensorEntity):

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -2,7 +2,6 @@
 
 import logging
 from typing import List, Union
-from asyncio import TimeoutError, wait_for
 
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.sensor import SensorEntity

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -70,9 +70,6 @@ class WattBoxSensor(WattBoxEntity, SensorEntity):
         self.sensor_type: str = sensor_type
         self._attr_name = f"{name} {SENSOR_TYPES[self.sensor_type]['name']}"
         self._attr_native_unit_of_measurement = SENSOR_TYPES[self.sensor_type]["unit"]
-        self._attr_suggested_unit_of_measurement = SENSOR_TYPES[self.sensor_type][
-            "unit"
-        ]
         self._attr_icon = SENSOR_TYPES[self.sensor_type]["icon"]
         self._attr_unique_id = f"{self._wattbox.serial_number}-sensor-{sensor_type}"
 

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -70,6 +70,9 @@ class WattBoxSensor(WattBoxEntity, SensorEntity):
         self.sensor_type: str = sensor_type
         self._attr_name = f"{name} {SENSOR_TYPES[self.sensor_type]['name']}"
         self._attr_native_unit_of_measurement = SENSOR_TYPES[self.sensor_type]["unit"]
+        self._attr_suggested_unit_of_measurement = SENSOR_TYPES[self.sensor_type][
+            "unit"
+        ]
         self._attr_icon = SENSOR_TYPES[self.sensor_type]["icon"]
         self._attr_unique_id = f"{self._wattbox.serial_number}-sensor-{sensor_type}"
 

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import List, Union
+from datetime import timedelta
 
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.components.sensor import SensorEntity


### PR DESCRIPTION
Fixes #15

I have multiple Wattboxes and frequently when the component loads, it times out, and I have to restart HA to make it try to reload. This PR adds try blocks inside each `async_setup_platform` that throw a `PlatformNotReady` if the wattbox entity can't be added as an entity. My catch statement is naive and assuming any failures are due to the platform not being ready, but they're better than nothing. 

(Sorry for the temp reverts in the commit history, I was doing some janky testing.)