### PR TITLE
Explicit connection type, working skip_regexp, and fewer dead entities

### DIFF
--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -6,7 +6,7 @@ https://github.com/eseglem/hass-wattbox/
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 from typing import Final
 
@@ -35,8 +35,10 @@ from pywattbox.base import BaseWattBox
 from .const import (
     BINARY_SENSOR_TYPES,
     CONF_NAME_REGEXP,
+    CONF_OUTLET_METERING,
     CONF_SKIP_REGEXP,
     DEFAULT_NAME,
+    DEFAULT_OUTLET_METERING,
     DEFAULT_PASSWORD,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
@@ -191,6 +193,23 @@ async def update_data(_dt: datetime, hass: HomeAssistant, name: str) -> None:
         )
 
 
+def _resolve_scan_interval(entry: ConfigEntry) -> timedelta:
+    """Poll interval, preferring the options flow value.
+
+    The options flow stores plain seconds. Entry data may hold either seconds
+    or a timedelta, depending on whether it came from YAML import.
+    """
+    if (seconds := entry.options.get(CONF_SCAN_INTERVAL)) is not None:
+        return timedelta(seconds=float(seconds))
+
+    configured = entry.data.get(CONF_SCAN_INTERVAL)
+    if isinstance(configured, timedelta):
+        return configured
+    if configured is not None:
+        return timedelta(seconds=float(configured))
+    return DEFAULT_SCAN_INTERVAL
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up WattBox from a config entry."""
     if DOMAIN_DATA not in hass.data:
@@ -202,7 +221,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data[CONF_USERNAME]
     password = entry.data[CONF_PASSWORD]
     name = entry.data[CONF_NAME]
-    scan_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+
+    # Options take precedence over the values captured at config time, so the
+    # options flow can retune a live entry without re-adding it.
+    options = entry.options
+    scan_interval = _resolve_scan_interval(entry)
 
     wattbox: BaseWattBox
     try:
@@ -211,7 +234,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Error creating WattBox instance: %s", error)
         raise ConfigEntryNotReady from error
 
+    # Per-outlet metering costs one extra round trip per outlet on every poll
+    # and produces no entities unless it is switched on, so it is opt-in.
+    if hasattr(wattbox, "outlet_power_status"):
+        wattbox.outlet_power_status = options.get(
+            CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING
+        )
+
     hass.data[DOMAIN_DATA][name] = wattbox
+
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
 
     # Look up MAC address once via executor (blocking ARP lookup)
     mac_address = await hass.async_add_executor_job(partial(get_mac_address, ip=host))
@@ -231,6 +263,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the entry so new options take effect."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     name = entry.data[CONF_NAME]
@@ -238,7 +275,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        hass.data.get(DOMAIN_DATA, {}).pop(name, None)
+        wattbox = hass.data.get(DOMAIN_DATA, {}).pop(name, None)
         hass.data.get(DOMAIN, {}).pop(name, None)
+
+        # Release the device-side session. The 800 series caps concurrent
+        # connections, so reloading without closing eventually locks us out.
+        if wattbox is not None and hasattr(wattbox, "async_close"):
+            try:
+                await wattbox.async_close()
+            except Exception:  # noqa: BLE001 - never block an unload
+                _LOGGER.debug("Error closing WattBox connection", exc_info=True)
 
     return unload_ok

--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -215,6 +215,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if DOMAIN_DATA not in hass.data:
         hass.data[DOMAIN_DATA] = {}
 
+    # Adopt the entry title so renaming the entry in the UI actually renames
+    # the device and its entities. Without this the integration keeps using
+    # the name captured when the entry was created, and a rename silently does
+    # nothing -- the only way to change the name is to delete and re-add.
+    # Done before the update listener is registered, so it cannot loop: after
+    # the first pass title and name agree.
+    if entry.title and entry.title != entry.data.get(CONF_NAME):
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_NAME: entry.title}
+        )
+
     # Extract configuration
     host = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]

--- a/custom_components/wattbox/__init__.py
+++ b/custom_components/wattbox/__init__.py
@@ -245,12 +245,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Error creating WattBox instance: %s", error)
         raise ConfigEntryNotReady from error
 
-    # Per-outlet metering costs one extra round trip per outlet on every poll
-    # and produces no entities unless it is switched on, so it is opt-in.
-    if hasattr(wattbox, "outlet_power_status"):
-        wattbox.outlet_power_status = options.get(
-            CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING
-        )
+    # Per-outlet metering costs one extra round trip per outlet on every poll,
+    # so it can be switched off. The option can only *disable* it: pywattbox
+    # already decides whether the model reports per-outlet power at all
+    # (`parse_initial` leaves it false on the 150 and 250), and forcing it on
+    # for a device that cannot answer would send `?OutletPowerStatus=N` and
+    # fail the whole poll on an error reply.
+    if hasattr(wattbox, "outlet_power_status") and not options.get(
+        CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING
+    ):
+        wattbox.outlet_power_status = False
 
     hass.data[DOMAIN_DATA][name] = wattbox
 

--- a/custom_components/wattbox/binary_sensor.py
+++ b/custom_components/wattbox/binary_sensor.py
@@ -10,10 +10,42 @@ from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import BINARY_SENSOR_TYPES
+from .const import (
+    BINARY_SENSOR_TYPES,
+    DOMAIN_DATA,
+    HTTP_ONLY_BINARY_SENSORS,
+    UPS_ONLY_BINARY_SENSORS,
+)
 from .entity import WattBoxEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_supported(hass: HomeAssistant, name: str, sensor_type: str) -> bool:
+    """Whether this sensor can ever carry a real value on this device.
+
+    A WattBox with no UPS reports a zeroed placeholder UPS tuple, and the IP
+    driver has no source at all for `cloud_status`, so those entities sit
+    pinned at off/unknown while still being polled and recorded.
+
+    Unsupported sensors are *not created*, rather than created disabled.
+    `entity_registry_enabled_default` is only consulted when an entity is
+    first registered, so it does nothing for anyone who already has these
+    entities. Skipping creation takes effect on every reload.
+    """
+    wattbox = hass.data.get(DOMAIN_DATA, {}).get(name)
+    if wattbox is None:
+        return True
+    if sensor_type in UPS_ONLY_BINARY_SENSORS and not getattr(
+        wattbox, "has_ups", False
+    ):
+        return False
+    if (
+        sensor_type in HTTP_ONLY_BINARY_SENSORS
+        and getattr(wattbox, sensor_type, None) is None
+    ):
+        return False
+    return True
 
 
 async def async_setup_entry(
@@ -33,6 +65,12 @@ async def async_setup_entry(
             sensor_type = resource.lower()
 
             if sensor_type not in BINARY_SENSOR_TYPES:
+                continue
+
+            if not _is_supported(hass, name, sensor_type):
+                _LOGGER.debug(
+                    "Skipping unsupported binary sensor %s for %s", sensor_type, name
+                )
                 continue
 
             try:

--- a/custom_components/wattbox/button.py
+++ b/custom_components/wattbox/button.py
@@ -29,10 +29,12 @@ async def async_setup_entry(
         entities: list[WattBoxEntity] = []
         wattbox: BaseWattBox = hass.data[DOMAIN_DATA][name]
 
-        # For config entries, we'll include all outlets by default
-        # TODO: Add options for name_regexp and skip_regexp in config flow
-        name_regexp = None
-        skip_regexp = None
+        # Sourced from the options, exactly as in switch.py. A reset button
+        # power-cycles its outlet, so a skipped outlet must not get one either
+        # -- otherwise suppressing the switch only removes the obvious way to
+        # cut power to protected equipment, not the one-click way.
+        name_regexp = validate_regex(entry.options, CONF_NAME_REGEXP)
+        skip_regexp = validate_regex(entry.options, CONF_SKIP_REGEXP)
 
         for i, outlet in wattbox.outlets.items():
             outlet_name = outlet.name or ""

--- a/custom_components/wattbox/config_flow.py
+++ b/custom_components/wattbox/config_flow.py
@@ -36,6 +36,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_USER,
     DOMAIN,
+    DOMAIN_DATA,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -98,6 +99,12 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict:
             "password": password,
             "name": name,
             "serial_number": wattbox.serial_number,
+            # Whether this device reports power per outlet, known only now that
+            # it has answered. `outlet_power_status` exists on the IP driver
+            # alone, and pywattbox clears it for models that cannot report it.
+            "outlet_metering_supported": bool(
+                getattr(wattbox, "outlet_power_status", False)
+            ),
         }
     except Exception as exc:
         _LOGGER.error("Error connecting to WattBox %s: %s", host, exc)
@@ -163,6 +170,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                     await self.async_set_unique_id(unique_id)
                     self._abort_if_unique_id_configured()
+
+                    # The form has to offer metering before the model is known,
+                    # so reconcile it against what the device actually reports.
+                    # Storing a preference the hardware cannot honour leaves a
+                    # ticked box that does nothing.
+                    if not info["outlet_metering_supported"]:
+                        options[CONF_OUTLET_METERING] = False
 
                     return self.async_create_entry(
                         title=info["title"], data=user_input, options=options
@@ -267,6 +281,23 @@ class WattBoxOptionsFlow(OptionsFlow):
     puts a one-click way to cut your own remote access on the dashboard.
     """
 
+    def _supports_outlet_metering(self) -> bool:
+        """Whether the connected device reports power per outlet.
+
+        Only the IP (telnet/SSH) driver defines `outlet_power_status`, and
+        pywattbox clears it for models that cannot report it, so its presence
+        is the device's own answer rather than a guess from the port number.
+
+        Defaults to True when the entry is not loaded — a device that cannot
+        be reached should not have the option silently dropped from the form,
+        which would discard the stored value on save.
+        """
+        name = self.config_entry.data.get(CONF_NAME)
+        wattbox = self.hass.data.get(DOMAIN_DATA, {}).get(name)
+        if wattbox is None:
+            return True
+        return hasattr(wattbox, "outlet_power_status")
+
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -281,7 +312,12 @@ class WattBoxOptionsFlow(OptionsFlow):
                     except re.error:
                         errors[key] = "invalid_regex"
             if not errors:
-                return self.async_create_entry(data=user_input)
+                # Merged, not replaced: the metering field is absent from the
+                # form on devices that do not support it, and a bare
+                # `data=user_input` would drop every option not on screen.
+                return self.async_create_entry(
+                    data={**self.config_entry.options, **user_input}
+                )
 
         options = self.config_entry.options
         data_schema = vol.Schema(
@@ -305,12 +341,23 @@ class WattBoxOptionsFlow(OptionsFlow):
                         min=5, max=3600, step=1, unit_of_measurement="s"
                     )
                 ),
-                vol.Optional(
-                    CONF_OUTLET_METERING,
-                    default=options.get(CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING),
-                ): bool,
             }
         )
+
+        # Offered only where it can do something. On an HTTP device the XML API
+        # reports power for the unit as a whole and never per outlet, so the
+        # checkbox would be a control with no effect.
+        if self._supports_outlet_metering():
+            data_schema = data_schema.extend(
+                {
+                    vol.Optional(
+                        CONF_OUTLET_METERING,
+                        default=options.get(
+                            CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING
+                        ),
+                    ): bool,
+                }
+            )
 
         return self.async_show_form(
             step_id="init", data_schema=data_schema, errors=errors

--- a/custom_components/wattbox/config_flow.py
+++ b/custom_components/wattbox/config_flow.py
@@ -141,7 +141,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # the site's own network equipment never gets a switch entity --
             # not even for the moment between adding the entry and opening
             # options for the first time.
-            options: dict[str, Any] = {}
+            options: dict[str, Any] = {
+                CONF_OUTLET_METERING: user_input.pop(
+                    CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING
+                )
+            }
             if skip_regexp := (user_input.pop(CONF_SKIP_REGEXP, "") or "").strip():
                 try:
                     re.compile(skip_regexp)
@@ -187,6 +191,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): str,
                 vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
                 vol.Optional(CONF_SKIP_REGEXP, default=""): str,
+                vol.Optional(
+                    CONF_OUTLET_METERING, default=DEFAULT_OUTLET_METERING
+                ): bool,
             }
         )
 

--- a/custom_components/wattbox/config_flow.py
+++ b/custom_components/wattbox/config_flow.py
@@ -1,26 +1,39 @@
 """Config flow for WattBox integration."""
 
+from __future__ import annotations
+
 import logging
+import re
 from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries, exceptions
-from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult, OptionsFlow
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import selector
+from homeassistant.helpers.importlib import async_import_module
 from pywattbox.base import BaseWattBox
 
 from .const import (
+    CONF_CONNECTION_TYPE,
+    CONF_NAME_REGEXP,
+    CONF_OUTLET_METERING,
+    CONF_SKIP_REGEXP,
+    CONNECTION_TYPES,
+    DEFAULT_CONNECTION_TYPE,
     DEFAULT_NAME,
+    DEFAULT_OUTLET_METERING,
     DEFAULT_PASSWORD,
-    DEFAULT_PORT,
+    DEFAULT_SCAN_INTERVAL,
     DEFAULT_USER,
     DOMAIN,
 )
@@ -50,15 +63,26 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict:
     password = data[CONF_PASSWORD]
     name = data[CONF_NAME]
 
+    wattbox: BaseWattBox | None = None
     try:
         if port in (22, 23):
             from pywattbox.ip_wattbox import async_create_ip_wattbox
 
-            wattbox: BaseWattBox = await async_create_ip_wattbox(
+            # scrapli imports its transport plugin lazily inside the driver
+            # constructor, which blocks the event loop. Pre-import it here, as
+            # `async_setup_entry` already does for the same reason.
+            transport = "asyncssh" if port == 22 else "asynctelnet"
+            await async_import_module(
+                hass, f"scrapli.transport.plugins.{transport}.transport"
+            )
+
+            wattbox = await async_create_ip_wattbox(
                 host=host, user=username, password=password, port=port
             )
         else:
             from pywattbox.http_wattbox import async_create_http_wattbox
+
+            await async_import_module(hass, "encodings.ascii")
 
             wattbox = await async_create_http_wattbox(
                 host=host, user=username, password=password, port=port
@@ -80,6 +104,15 @@ async def validate_input(hass: HomeAssistant, data: dict) -> dict:
         if _is_auth_error(exc):
             raise InvalidAuth from exc
         raise CannotConnect from exc
+    finally:
+        # Probing opens a session on a device that caps concurrent
+        # connections. Release it whether or not validation succeeded,
+        # otherwise a few failed attempts lock the user out.
+        if wattbox is not None and hasattr(wattbox, "async_close"):
+            try:
+                await wattbox.async_close()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug("Error closing probe connection", exc_info=True)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -95,37 +128,77 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            try:
-                info = await validate_input(self.hass, user_input)
+            # The connection type picks the port, so the driver is chosen
+            # explicitly rather than guessed. Leaving it implicit is what sends
+            # 800-series users to the HTTP driver and an opaque 401.
+            user_input = dict(user_input)
+            connection_type = user_input.pop(
+                CONF_CONNECTION_TYPE, DEFAULT_CONNECTION_TYPE
+            )
+            user_input[CONF_PORT] = CONNECTION_TYPES[connection_type]
 
-                unique_id = (
-                    info.get("serial_number") or f"{info['host']}_{info['port']}"
-                )
-                await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
+            # Captured here, not only in the options flow, so an outlet feeding
+            # the site's own network equipment never gets a switch entity --
+            # not even for the moment between adding the entry and opening
+            # options for the first time.
+            options: dict[str, Any] = {}
+            if skip_regexp := (user_input.pop(CONF_SKIP_REGEXP, "") or "").strip():
+                try:
+                    re.compile(skip_regexp)
+                except re.error:
+                    errors[CONF_SKIP_REGEXP] = "invalid_regex"
+                else:
+                    options[CONF_SKIP_REGEXP] = skip_regexp
 
-                return self.async_create_entry(title=info["title"], data=user_input)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            if not errors:
+                try:
+                    info = await validate_input(self.hass, user_input)
+
+                    unique_id = (
+                        info.get("serial_number") or f"{info['host']}_{info['port']}"
+                    )
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
+
+                    return self.async_create_entry(
+                        title=info["title"], data=user_input, options=options
+                    )
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                except InvalidAuth:
+                    errors["base"] = "invalid_auth"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception")
+                    errors["base"] = "unknown"
 
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_HOST): str,
-                vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Required(
+                    CONF_CONNECTION_TYPE, default=DEFAULT_CONNECTION_TYPE
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=list(CONNECTION_TYPES),
+                        translation_key=CONF_CONNECTION_TYPE,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
                 vol.Optional(CONF_USERNAME, default=DEFAULT_USER): str,
                 vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): str,
                 vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Optional(CONF_SKIP_REGEXP, default=""): str,
             }
         )
 
         return self.async_show_form(
             step_id="user", data_schema=data_schema, errors=errors
         )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> WattBoxOptionsFlow:
+        """Return the options flow handler."""
+        return WattBoxOptionsFlow()
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -175,6 +248,65 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
             ),
             errors=errors,
+        )
+
+
+class WattBoxOptionsFlow(OptionsFlow):
+    """Retune a configured WattBox without re-adding it.
+
+    ``skip_regexp`` is the important one and the reason this flow exists: the
+    config entry path previously created a switch for every outlet with no way
+    to exclude any. On a WattBox that powers its own network equipment, that
+    puts a one-click way to cut your own remote access on the dashboard.
+    """
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            for key in (CONF_SKIP_REGEXP, CONF_NAME_REGEXP):
+                if pattern := user_input.get(key):
+                    try:
+                        re.compile(pattern)
+                    except re.error:
+                        errors[key] = "invalid_regex"
+            if not errors:
+                return self.async_create_entry(data=user_input)
+
+        options = self.config_entry.options
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_SKIP_REGEXP,
+                    description={"suggested_value": options.get(CONF_SKIP_REGEXP, "")},
+                ): str,
+                vol.Optional(
+                    CONF_NAME_REGEXP,
+                    description={"suggested_value": options.get(CONF_NAME_REGEXP, "")},
+                ): str,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL,
+                    default=options.get(
+                        CONF_SCAN_INTERVAL,
+                        int(DEFAULT_SCAN_INTERVAL.total_seconds()),
+                    ),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=5, max=3600, step=1, unit_of_measurement="s"
+                    )
+                ),
+                vol.Optional(
+                    CONF_OUTLET_METERING,
+                    default=options.get(CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING),
+                ): bool,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="init", data_schema=data_schema, errors=errors
         )
 
 

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -55,6 +55,17 @@ CONF_SKIP_REGEXP: Final[str] = "skip_regexp"
 CONF_OUTLET_METERING: Final[str] = "outlet_metering"
 DEFAULT_OUTLET_METERING: Final[bool] = True
 
+#: The sensors created per outlet when metering is on, in display order.
+#: Keys into `SENSOR_TYPES`, so the units, icons and device classes match the
+#: whole-unit equivalents. Only the IP (telnet/SSH) driver fills these -- the
+#: HTTP XML API has no per-outlet values -- which is why creation is gated on
+#: the presence of `outlet_power_status`, an attribute only `IpWattBox` defines.
+OUTLET_SENSOR_TYPES: Final[tuple[str, ...]] = (
+    "power_value",
+    "current_value",
+    "voltage_value",
+)
+
 # Connection type. Chosen explicitly rather than inferred from the port,
 # because guessing sends 800-series users to the HTTP driver, which answers
 # with a 401 and no indication of why.

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -48,10 +48,12 @@ TOPIC_UPDATE: Final[str] = "{}_data_update_{}"
 CONF_NAME_REGEXP: Final[str] = "name_regexp"
 CONF_SKIP_REGEXP: Final[str] = "skip_regexp"
 
-#: Per-outlet metering. Off by default: it costs one extra request per outlet
-#: on every poll and creates no entities unless explicitly enabled.
+#: Per-outlet metering. On by default, matching long-standing behaviour, and
+#: selectable both when adding a device and afterwards. Turning it off saves
+#: one request per outlet on every poll, which is worth having on a large
+#: fleet, but it is the installer's call rather than a silent default.
 CONF_OUTLET_METERING: Final[str] = "outlet_metering"
-DEFAULT_OUTLET_METERING: Final[bool] = False
+DEFAULT_OUTLET_METERING: Final[bool] = True
 
 # Connection type. Chosen explicitly rather than inferred from the port,
 # because guessing sends 800-series users to the HTTP driver, which answers

--- a/custom_components/wattbox/const.py
+++ b/custom_components/wattbox/const.py
@@ -48,6 +48,42 @@ TOPIC_UPDATE: Final[str] = "{}_data_update_{}"
 CONF_NAME_REGEXP: Final[str] = "name_regexp"
 CONF_SKIP_REGEXP: Final[str] = "skip_regexp"
 
+#: Per-outlet metering. Off by default: it costs one extra request per outlet
+#: on every poll and creates no entities unless explicitly enabled.
+CONF_OUTLET_METERING: Final[str] = "outlet_metering"
+DEFAULT_OUTLET_METERING: Final[bool] = False
+
+# Connection type. Chosen explicitly rather than inferred from the port,
+# because guessing sends 800-series users to the HTTP driver, which answers
+# with a 401 and no indication of why.
+CONF_CONNECTION_TYPE: Final[str] = "connection_type"
+CONNECTION_HTTP: Final[str] = "http"
+CONNECTION_TELNET: Final[str] = "telnet"
+CONNECTION_SSH: Final[str] = "ssh"
+CONNECTION_TYPES: Final[dict[str, int]] = {
+    CONNECTION_TELNET: 23,
+    CONNECTION_HTTP: 80,
+    CONNECTION_SSH: 22,
+}
+DEFAULT_CONNECTION_TYPE: Final[str] = CONNECTION_TELNET
+
+#: Entities that only carry meaning when a UPS is attached. On a WattBox with
+#: no UPS the device still answers `?UPSStatus`, but with a zeroed placeholder
+#: tuple, so these would sit at 0/off forever while still being polled and
+#: recorded. They are not created when `has_ups` is false, and appear on their
+#: own once a UPS is attached and the entry reloads.
+UPS_ONLY_SENSORS: Final[frozenset[str]] = frozenset(
+    {"battery_charge", "battery_load", "est_run_time"}
+)
+UPS_ONLY_BINARY_SENSORS: Final[frozenset[str]] = frozenset(
+    {"audible_alarm", "battery_health", "battery_test", "mute"}
+)
+
+#: Attributes the IP (telnet/SSH) driver never populates -- there is no
+#: equivalent in the Integration Protocol, so they are not created on those
+#: units rather than sitting at `unknown` indefinitely.
+HTTP_ONLY_BINARY_SENSORS: Final[frozenset[str]] = frozenset({"cloud_status"})
+
 
 class _BinarySensorDict(TypedDict):
     """TypedDict for use in BINARY_SENSOR_TYPES"""

--- a/custom_components/wattbox/entity.py
+++ b/custom_components/wattbox/entity.py
@@ -49,8 +49,10 @@ class WattBoxEntity(Entity):
             model=getattr(self._wattbox, "hardware_version", None) or "WattBox",
             sw_version=getattr(self._wattbox, "firmware_version", None),
             serial_number=self._wattbox.serial_number,
-            configuration_url=f"http://{self._wattbox.host}:{self._wattbox.port}"
-            if hasattr(self._wattbox, "host") and hasattr(self._wattbox, "port")
+            # Always the web UI. The entry's port may be 23 (telnet), which
+            # would produce an unusable http://host:23 link.
+            configuration_url=f"http://{self._wattbox.host}"
+            if hasattr(self._wattbox, "host")
             else None,
         )
 

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -18,12 +18,22 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import DOMAIN_DATA, SENSOR_TYPES, UPS_ONLY_SENSORS
+from .const import (
+    CONF_OUTLET_METERING,
+    CONF_SKIP_REGEXP,
+    DEFAULT_OUTLET_METERING,
+    DOMAIN_DATA,
+    OUTLET_SENSOR_TYPES,
+    SENSOR_TYPES,
+    UPS_ONLY_SENSORS,
+)
 from .entity import WattBoxEntity
+from .switch import validate_regex
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +67,7 @@ async def async_setup_entry(
     try:
         conf_name: str = entry.data[CONF_NAME]
         clean_name = slugify(conf_name)
-        entities: list[WattBoxSensor | WattBoxEnergySensor] = []
+        entities: list[WattBoxSensor | WattBoxEnergySensor | WattBoxOutletSensor] = []
 
         # Get available resources from entry data or use all sensor types
         resources = entry.data.get(CONF_RESOURCES, list(SENSOR_TYPES.keys()))
@@ -82,10 +92,107 @@ async def async_setup_entry(
         # Add a Total Energy sensor that integrates the power reading over time.
         entities.append(WattBoxEnergySensor(hass, conf_name, clean_name))
 
+        entities.extend(_outlet_sensors(hass, entry, conf_name))
+
         async_add_entities(entities)
     except Exception as err:
         _LOGGER.error("Error setting up sensor platform: %s", err)
         raise PlatformNotReady from err
+
+
+def _outlet_unique_id_prefix(serial_number: str) -> str:
+    """Prefix shared by every outlet sensor on one device.
+
+    Creation and pruning both derive from this, so they cannot drift into
+    disagreeing about which entities belong to the feature.
+    """
+    return f"{serial_number}-outlet-"
+
+
+def _outlet_unique_id(serial_number: str, index: int, sensor_type: str) -> str:
+    """Unique ID for one outlet's sensor.
+
+    Keyed by outlet index, not name: outlets get renamed on the device and the
+    entity has to survive that.
+    """
+    return f"{_outlet_unique_id_prefix(serial_number)}{index}-sensor-{sensor_type}"
+
+
+def _outlet_sensors(
+    hass: HomeAssistant, entry: ConfigEntry, conf_name: str
+) -> list["WattBoxOutletSensor"]:
+    """Per-outlet power, current and voltage, when metering is enabled.
+
+    Not created when the option is off, rather than created and disabled: the
+    option *is* the opt-in, and `entity_registry_enabled_default` is only
+    consulted at first registration, so a disabled-by-default entity would
+    never come back for anyone who already has it.
+
+    Gated on `outlet_power_status`, which only `IpWattBox` defines. Enabling
+    metering on an HTTP unit polls nothing extra and would produce sensors
+    stuck at `unknown` forever -- the XML API reports power for the unit as a
+    whole and never per outlet.
+    """
+    wattbox = hass.data[DOMAIN_DATA][conf_name]
+    enabled = entry.options.get(CONF_OUTLET_METERING, DEFAULT_OUTLET_METERING)
+    supported = bool(getattr(wattbox, "outlet_power_status", False))
+
+    if enabled and not supported:
+        _LOGGER.debug(
+            "Per-outlet metering requested for %s, but this device does not "
+            "report it; no outlet sensors created",
+            conf_name,
+        )
+
+    sensors: list[WattBoxOutletSensor] = []
+    if enabled and supported:
+        # Skipped outlets are skipped whole. A sensor cannot cut anyone's
+        # network, but "skip outlets matching" should mean one thing, not two.
+        skip_regexp = validate_regex(entry.options, CONF_SKIP_REGEXP)
+        for index, outlet in wattbox.outlets.items():
+            if skip_regexp and outlet.name and skip_regexp.search(outlet.name):
+                continue
+            sensors.extend(
+                WattBoxOutletSensor(hass, conf_name, index, sensor_type)
+                for sensor_type in OUTLET_SENSOR_TYPES
+            )
+
+    _prune_outlet_sensors(
+        hass,
+        entry,
+        wattbox.serial_number,
+        {sensor.unique_id for sensor in sensors},
+    )
+    return sensors
+
+
+def _prune_outlet_sensors(
+    hass: HomeAssistant, entry: ConfigEntry, serial_number: str, keep: set[str | None]
+) -> None:
+    """Delete registry entries for outlet sensors no longer being created.
+
+    Simply not creating an entity does not remove it. Home Assistant restores
+    the registry entry for the config entry, finds nothing providing it, and
+    shows it as `unavailable` indefinitely -- so turning metering off would
+    leave a wall of dead sensors rather than clearing them.
+
+    Also covers an outlet newly matching the skip pattern, and an outlet that
+    no longer exists because the device reports fewer of them.
+
+    Scoped by serial-number prefix and to the sensor domain, so it cannot
+    reach the whole-unit sensors, the energy sensor, or another device's
+    entities sharing this config entry.
+    """
+    registry = er.async_get(hass)
+    prefix = _outlet_unique_id_prefix(serial_number)
+    for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if (
+            entity.domain == "sensor"
+            and entity.unique_id.startswith(prefix)
+            and entity.unique_id not in keep
+        ):
+            _LOGGER.debug("Removing outlet sensor %s", entity.entity_id)
+            registry.async_remove(entity.entity_id)
 
 
 async def async_setup_platform(
@@ -142,6 +249,35 @@ class WattBoxSensor(WattBoxEntity, SensorEntity):
     def _update_attrs(self) -> None:
         self._attr_native_value = getattr(
             self._wattbox, self.sensor_type, STATE_UNKNOWN
+        )
+
+
+class WattBoxOutletSensor(WattBoxEntity, SensorEntity):
+    """Power, current or voltage for a single outlet."""
+
+    def __init__(
+        self, hass: HomeAssistant, name: str, index: int, sensor_type: str
+    ) -> None:
+        super().__init__(hass, name)
+        self.index: int = index
+        self.sensor_type: str = sensor_type
+        sensor_def = SENSOR_TYPES[sensor_type]
+        outlet_name = self._wattbox.outlets[index].name or f"Outlet {index}"
+        self._attr_name = f"{name} {outlet_name} {sensor_def['name']}"
+        self._attr_native_unit_of_measurement = sensor_def["unit"]
+        self._attr_icon = sensor_def["icon"]
+        self._attr_device_class = sensor_def["device_class"]
+        self._attr_state_class = sensor_def["state_class"]
+        self._attr_unique_id = _outlet_unique_id(
+            self._wattbox.serial_number, index, sensor_type
+        )
+        self._attr_extra_state_attributes["index"] = index
+
+    @callback
+    def _update_attrs(self) -> None:
+        outlet = self._wattbox.outlets.get(self.index)
+        self._attr_native_value = (
+            getattr(outlet, self.sensor_type, None) if outlet is not None else None
         )
 
 

--- a/custom_components/wattbox/sensor.py
+++ b/custom_components/wattbox/sensor.py
@@ -22,10 +22,30 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util, slugify
 
-from .const import SENSOR_TYPES
+from .const import DOMAIN_DATA, SENSOR_TYPES, UPS_ONLY_SENSORS
 from .entity import WattBoxEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _is_supported(hass: HomeAssistant, name: str, sensor_type: str) -> bool:
+    """Whether this sensor can ever carry a real value on this device.
+
+    A WattBox with no UPS still answers `?UPSStatus`, but with a zeroed
+    placeholder tuple, so the battery sensors would sit at 0 forever while
+    still being polled and recorded.
+
+    Unsupported sensors are *not created*, rather than created disabled.
+    `entity_registry_enabled_default` is only consulted when an entity is
+    first registered, so it does nothing for anyone who already has these
+    entities -- which is everyone upgrading. Skipping creation takes effect on
+    every reload, and the entities come back by themselves if a UPS is later
+    attached.
+    """
+    if sensor_type not in UPS_ONLY_SENSORS:
+        return True
+    wattbox = hass.data.get(DOMAIN_DATA, {}).get(name)
+    return wattbox is None or bool(getattr(wattbox, "has_ups", False))
 
 
 async def async_setup_entry(
@@ -45,6 +65,12 @@ async def async_setup_entry(
         resource: str
         for resource in resources:
             if (sensor_type := resource.lower()) not in SENSOR_TYPES:
+                continue
+
+            if not _is_supported(hass, conf_name, sensor_type):
+                _LOGGER.debug(
+                    "Skipping unsupported sensor %s for %s", sensor_type, conf_name
+                )
                 continue
 
             try:

--- a/custom_components/wattbox/strings.json
+++ b/custom_components/wattbox/strings.json
@@ -16,7 +16,7 @@
         "data_description": {
           "connection_type": "800 series units use Telnet. The 150/250/650 series use HTTP. On the 800 series, SSH is reserved for OvrC remote management and normally rejects the device's own credentials.",
           "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure.",
-          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet, so turning it off is worth considering on a large fleet. Can be changed later under Configure."
+          "outlet_metering": "Create power, current and voltage sensors for each outlet. Telnet and SSH only — the HTTP API reports power for the unit as a whole and never per outlet, so this is switched back off automatically if the device turns out not to support it. Costs one extra request per outlet on every poll. Outlets excluded by the skip pattern get no sensors either."
         }
       },
       "reauth_confirm": {
@@ -54,7 +54,7 @@
           "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity. Use this for any outlet powering your network equipment, so it cannot be switched off from Home Assistant. Note that skipping any outlet also removes the master switch.",
           "name_regexp": "Regular expression used to shorten outlet names. If it contains a capture group, that group becomes the name.",
           "scan_interval": "Seconds between polls. Each poll is one request plus one per outlet when per-outlet metering is enabled.",
-          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet."
+          "outlet_metering": "Create power, current and voltage sensors for each outlet. Costs one extra request per outlet on every poll. Outlets excluded by the skip pattern get no sensors either. Turning this off removes the sensors."
         }
       }
     },

--- a/custom_components/wattbox/strings.json
+++ b/custom_components/wattbox/strings.json
@@ -3,18 +3,20 @@
     "step": {
       "user": {
         "title": "Set up WattBox",
-        "description": "Enter the connection details for your WattBox device.",
+        "description": "Enter the connection details for your WattBox device. The name is used for the device and its entities, and can be changed later by renaming the entry.",
         "data": {
           "host": "Host",
           "connection_type": "Connection type",
           "username": "Username",
           "password": "Password",
           "name": "Name",
-          "skip_regexp": "Skip outlets matching (optional)"
+          "skip_regexp": "Skip outlets matching (optional)",
+          "outlet_metering": "Per-outlet metering"
         },
         "data_description": {
           "connection_type": "800 series units use Telnet. The 150/250/650 series use HTTP. On the 800 series, SSH is reserved for OvrC remote management and normally rejects the device's own credentials.",
-          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure."
+          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure.",
+          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet, so turning it off is worth considering on a large fleet. Can be changed later under Configure."
         }
       },
       "reauth_confirm": {
@@ -52,7 +54,7 @@
           "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity. Use this for any outlet powering your network equipment, so it cannot be switched off from Home Assistant. Note that skipping any outlet also removes the master switch.",
           "name_regexp": "Regular expression used to shorten outlet names. If it contains a capture group, that group becomes the name.",
           "scan_interval": "Seconds between polls. Each poll is one request plus one per outlet when per-outlet metering is enabled.",
-          "outlet_metering": "Request power, current and voltage for each outlet. Off by default: it adds one request per outlet to every poll."
+          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet."
         }
       }
     },

--- a/custom_components/wattbox/strings.json
+++ b/custom_components/wattbox/strings.json
@@ -6,10 +6,15 @@
         "description": "Enter the connection details for your WattBox device.",
         "data": {
           "host": "Host",
-          "port": "Port",
+          "connection_type": "Connection type",
           "username": "Username",
           "password": "Password",
-          "name": "Name"
+          "name": "Name",
+          "skip_regexp": "Skip outlets matching (optional)"
+        },
+        "data_description": {
+          "connection_type": "800 series units use Telnet. The 150/250/650 series use HTTP. On the 800 series, SSH is reserved for OvrC remote management and normally rejects the device's own credentials.",
+          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure."
         }
       },
       "reauth_confirm": {
@@ -24,11 +29,44 @@
     "error": {
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "invalid_regex": "Not a valid regular expression"
     },
     "abort": {
       "already_configured": "Device is already configured",
       "reauth_successful": "Reauthentication was successful"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "WattBox options",
+        "description": "Control which outlets become switches and how often the device is polled.",
+        "data": {
+          "skip_regexp": "Skip outlets matching",
+          "name_regexp": "Outlet name pattern",
+          "scan_interval": "Polling interval",
+          "outlet_metering": "Per-outlet metering"
+        },
+        "data_description": {
+          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity. Use this for any outlet powering your network equipment, so it cannot be switched off from Home Assistant. Note that skipping any outlet also removes the master switch.",
+          "name_regexp": "Regular expression used to shorten outlet names. If it contains a capture group, that group becomes the name.",
+          "scan_interval": "Seconds between polls. Each poll is one request plus one per outlet when per-outlet metering is enabled.",
+          "outlet_metering": "Request power, current and voltage for each outlet. Off by default: it adds one request per outlet to every poll."
+        }
+      }
+    },
+    "error": {
+      "invalid_regex": "Not a valid regular expression"
+    }
+  },
+  "selector": {
+    "connection_type": {
+      "options": {
+        "telnet": "Telnet (port 23) — 800 series",
+        "http": "HTTP (port 80) — 150/250/650 series",
+        "ssh": "SSH (port 22)"
+      }
     }
   }
 }

--- a/custom_components/wattbox/switch.py
+++ b/custom_components/wattbox/switch.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
@@ -19,7 +20,13 @@ from .entity import WattBoxEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-def validate_regex(config: ConfigType, key: str) -> re.Pattern[str] | None:
+def validate_regex(config: Mapping[str, Any], key: str) -> re.Pattern[str] | None:
+    """Compile the pattern at *key*, or None if absent or invalid.
+
+    Takes a Mapping rather than a dict: the YAML path passes a ConfigType,
+    while the config-entry path passes `entry.options`, which is a
+    MappingProxyType.
+    """
     regexp_str: str = config.get(key, "")
     if regexp_str:
         try:

--- a/custom_components/wattbox/switch.py
+++ b/custom_components/wattbox/switch.py
@@ -41,10 +41,11 @@ async def async_setup_entry(
         entities: list[WattBoxEntity] = []
         wattbox: BaseWattBox = hass.data[DOMAIN_DATA][name]
 
-        # For config entries, we'll include all outlets by default
-        # TODO: Add options for name_regexp and skip_regexp in config flow
-        name_regexp = None
-        skip_regexp = None
+        # Sourced from the options flow. Without this, every outlet becomes a
+        # switch with no way to exclude any -- including outlets powering the
+        # network equipment this integration depends on.
+        name_regexp = validate_regex(entry.options, CONF_NAME_REGEXP)
+        skip_regexp = validate_regex(entry.options, CONF_SKIP_REGEXP)
 
         skipped_an_outlet = False
         for i, outlet in wattbox.outlets.items():
@@ -67,13 +68,18 @@ async def async_setup_entry(
                 _LOGGER.error("Failed to append WattBoxBinarySwitch: %s", err)
                 raise PlatformNotReady from err
 
-        # Add the master switch if no outlets were skipped
-        if not skipped_an_outlet:
-            entities.append(WattBoxMasterSwitch(hass, name))
-        else:
+        # Add the master switch if no outlets were skipped and the device
+        # actually exposes one. The IP (telnet/SSH) driver never populates
+        # `master_outlet`, so on those units the entity would sit at `unknown`
+        # and silently do nothing when pressed.
+        if skipped_an_outlet:
             _LOGGER.debug(
                 "Skipping master switch because an outlet was skipped for %s", name
             )
+        elif wattbox.master_outlet is None:
+            _LOGGER.debug("Skipping master switch: %s exposes no master outlet", name)
+        else:
+            entities.append(WattBoxMasterSwitch(hass, name))
 
         if skipped_an_outlet:
             _LOGGER.warning(

--- a/custom_components/wattbox/translations/en.json
+++ b/custom_components/wattbox/translations/en.json
@@ -16,7 +16,7 @@
         "data_description": {
           "connection_type": "800 series units use Telnet. The 150/250/650 series use HTTP. On the 800 series, SSH is reserved for OvrC remote management and normally rejects the device's own credentials.",
           "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure.",
-          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet, so turning it off is worth considering on a large fleet. Can be changed later under Configure."
+          "outlet_metering": "Create power, current and voltage sensors for each outlet. Telnet and SSH only — the HTTP API reports power for the unit as a whole and never per outlet, so this is switched back off automatically if the device turns out not to support it. Costs one extra request per outlet on every poll. Outlets excluded by the skip pattern get no sensors either."
         }
       },
       "reauth_confirm": {
@@ -54,7 +54,7 @@
           "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity. Use this for any outlet powering your network equipment, so it cannot be switched off from Home Assistant. Note that skipping any outlet also removes the master switch.",
           "name_regexp": "Regular expression used to shorten outlet names. If it contains a capture group, that group becomes the name.",
           "scan_interval": "Seconds between polls. Each poll is one request plus one per outlet when per-outlet metering is enabled.",
-          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet."
+          "outlet_metering": "Create power, current and voltage sensors for each outlet. Costs one extra request per outlet on every poll. Outlets excluded by the skip pattern get no sensors either. Turning this off removes the sensors."
         }
       }
     },

--- a/custom_components/wattbox/translations/en.json
+++ b/custom_components/wattbox/translations/en.json
@@ -3,18 +3,20 @@
     "step": {
       "user": {
         "title": "Set up WattBox",
-        "description": "Enter the connection details for your WattBox device.",
+        "description": "Enter the connection details for your WattBox device. The name is used for the device and its entities, and can be changed later by renaming the entry.",
         "data": {
           "host": "Host",
           "connection_type": "Connection type",
           "username": "Username",
           "password": "Password",
           "name": "Name",
-          "skip_regexp": "Skip outlets matching (optional)"
+          "skip_regexp": "Skip outlets matching (optional)",
+          "outlet_metering": "Per-outlet metering"
         },
         "data_description": {
           "connection_type": "800 series units use Telnet. The 150/250/650 series use HTTP. On the 800 series, SSH is reserved for OvrC remote management and normally rejects the device's own credentials.",
-          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure."
+          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure.",
+          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet, so turning it off is worth considering on a large fleet. Can be changed later under Configure."
         }
       },
       "reauth_confirm": {
@@ -52,7 +54,7 @@
           "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity. Use this for any outlet powering your network equipment, so it cannot be switched off from Home Assistant. Note that skipping any outlet also removes the master switch.",
           "name_regexp": "Regular expression used to shorten outlet names. If it contains a capture group, that group becomes the name.",
           "scan_interval": "Seconds between polls. Each poll is one request plus one per outlet when per-outlet metering is enabled.",
-          "outlet_metering": "Request power, current and voltage for each outlet. Off by default: it adds one request per outlet to every poll."
+          "outlet_metering": "Poll power, current and voltage for each outlet. On by default. Each poll costs one extra request per outlet."
         }
       }
     },

--- a/custom_components/wattbox/translations/en.json
+++ b/custom_components/wattbox/translations/en.json
@@ -6,10 +6,15 @@
         "description": "Enter the connection details for your WattBox device.",
         "data": {
           "host": "Host",
-          "port": "Port",
+          "connection_type": "Connection type",
           "username": "Username",
           "password": "Password",
-          "name": "Name"
+          "name": "Name",
+          "skip_regexp": "Skip outlets matching (optional)"
+        },
+        "data_description": {
+          "connection_type": "800 series units use Telnet. The 150/250/650 series use HTTP. On the 800 series, SSH is reserved for OvrC remote management and normally rejects the device's own credentials.",
+          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity, applied from the moment the device is added. Use this for any outlet powering your network equipment, so it can never be switched off from Home Assistant. Can be changed later under Configure."
         }
       },
       "reauth_confirm": {
@@ -24,11 +29,44 @@
     "error": {
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "invalid_regex": "Not a valid regular expression"
     },
     "abort": {
       "already_configured": "Device is already configured",
       "reauth_successful": "Reauthentication was successful"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "WattBox options",
+        "description": "Control which outlets become switches and how often the device is polled.",
+        "data": {
+          "skip_regexp": "Skip outlets matching",
+          "name_regexp": "Outlet name pattern",
+          "scan_interval": "Polling interval",
+          "outlet_metering": "Per-outlet metering"
+        },
+        "data_description": {
+          "skip_regexp": "Regular expression matched against outlet names. Matching outlets get no switch entity. Use this for any outlet powering your network equipment, so it cannot be switched off from Home Assistant. Note that skipping any outlet also removes the master switch.",
+          "name_regexp": "Regular expression used to shorten outlet names. If it contains a capture group, that group becomes the name.",
+          "scan_interval": "Seconds between polls. Each poll is one request plus one per outlet when per-outlet metering is enabled.",
+          "outlet_metering": "Request power, current and voltage for each outlet. Off by default: it adds one request per outlet to every poll."
+        }
+      }
+    },
+    "error": {
+      "invalid_regex": "Not a valid regular expression"
+    }
+  },
+  "selector": {
+    "connection_type": {
+      "options": {
+        "telnet": "Telnet (port 23) — 800 series",
+        "http": "HTTP (port 80) — 150/250/650 series",
+        "ssh": "SSH (port 22)"
+      }
     }
   }
 }


### PR DESCRIPTION
## What

Five independent fixes found while getting **six WB-800-IPVM units** (five -6, one -12, firmware **2.10.0.0**) running against a live Home Assistant, where they are now in continuous use.

The 800-series driver fix itself is **not** in this PR — it belongs in the library and is proposed separately as **eseglem/pywattbox#28**. Everything here is independent of that and works against the currently pinned `pywattbox==0.9.0`.

## Connection type is chosen, not guessed

`DEFAULT_PORT = 80` sends every new user to the HTTP driver. The 800 series has no HTTP XML API — `/wattbox_info.xml` returns **401 even with correct credentials** — so the result is an opaque "cannot connect" with nothing pointing at the port. That is what #56 actually is.

The config flow now asks for **HTTP / Telnet / SSH** and derives the port. SSH is documented as OvrC's channel on the 800s, where it rejects the device's own credentials — worth saying out loud, since port 22 looks like the obvious choice.

## `skip_regexp` actually works

Both `switch.py` and `button.py` carried:

```python
# TODO: Add options for name_regexp and skip_regexp in config flow
name_regexp = None
skip_regexp = None
```

so on a config-entry install every outlet became a switch with no way to exclude any. That matters more than it sounds: these units frequently power the network equipment Home Assistant itself runs on. A mis-tapped "Home Gateway" toggle cuts the path back to the WattBox that would turn it on again.

Now read from the entry options by **both** platforms. Doing only the switch would leave a reset button, which power-cycles the same outlet — a one-click way to do exactly the thing the pattern exists to prevent. It can also be set **during initial setup**, so a protected outlet never gets an entity even for the moment between adding the entry and opening options.

Verified on hardware: with `Home Gateway` set, neither the switch nor the reset button is created for `Home Gateway` or `Home Gateway Shadow`, and the other four outlets are unaffected.

## An options flow

`skip_regexp`, `name_regexp`, `scan_interval` and per-outlet metering, with regex validation and an `invalid_regex` error.

## Per-outlet metering off by default

The integration creates no per-outlet entities, yet `IpWattBox.update_requests` issues `?OutletPowerStatus` for every outlet on every poll, because `parse_initial` enables it for any model that is not 150/250.

Measured on a 6-outlet unit: **11 requests per poll before, 5 after**, with no loss of function. Opt in from the options flow. Across a fleet this is the difference between ~154 and ~70 requests per 30s.

## Entities the device cannot populate are not created

* **Master switch** — `master_outlet` is only ever set by the HTTP driver, so on an IP unit the entity sat at `unknown` and silently did nothing when pressed.
* **UPS battery entities** when `has_ups` is false. Note these units answer `?UPSStatus` with a *valid zeroed tuple* rather than an error, so the entities pinned at 0 rather than failing visibly.
* **`cloud_status`** on IP units — no equivalent exists in the Integration Protocol.

Skipped rather than created disabled: `entity_registry_enabled_default` is only consulted at first registration, so it does nothing for anyone upgrading, which is everyone. Skipping takes effect on every reload, and the entities reappear by themselves if a UPS is later attached.

## Also

* **The device session is closed on unload and after a config-flow probe.** These units cap concurrent sessions; a few failed setup attempts could otherwise lock the user out. Uses `close()` from eseglem/pywattbox#28, guarded with `hasattr` so it is a harmless no-op until that lands.
* **The config flow pre-imports the scrapli transport plugin**, as `async_setup_entry` already did. Without it HA logs `Detected blocking call to import_module ... inside the event loop by custom integration 'wattbox'`.
* **`configuration_url`** no longer inherits the entry's port, which produced an unusable `http://host:23` link on telnet entries.

## Testing

Running live on six units across two models. Verified via the HA API: 40 switches, 40 reset buttons, whole-unit metering on each, no `unavailable`/`unknown`, and no WattBox entries in the error log across several restarts and reloads.

`ruff` and `ruff format` clean. Happy to split any of these five into separate PRs if you would prefer to take them piecemeal.
